### PR TITLE
feat: Phase 5 & 6 - Custom Health Score revamp + BYOK feature

### DIFF
--- a/finq-backend/app/api/chat.py
+++ b/finq-backend/app/api/chat.py
@@ -1,7 +1,7 @@
 """
 Chat and AI analysis API endpoints
 """
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Header
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from app.database import get_db
@@ -17,13 +17,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
-# Global instances
+# Global instances (used when no BYOK key is supplied)
 _analyzer: Optional[FinancialAnalyzer] = None
 _data_manager: Optional[DataSourceManager] = None
 
 
-def get_analyzer() -> FinancialAnalyzer:
-    """Get or create FinancialAnalyzer instance"""
+def get_analyzer(byok_key: Optional[str] = None) -> FinancialAnalyzer:
+    """Get or create FinancialAnalyzer instance.
+
+    If a BYOK key is provided (from the X-Gemini-API-Key header),
+    a fresh instance is created with that key for this request.
+    Otherwise, the global singleton backed by the backend's .env key is used.
+    """
+    if byok_key:
+        try:
+            return FinancialAnalyzer(api_key=byok_key)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Provided Gemini API key is invalid: {str(e)}"
+            )
+
     global _analyzer
     if _analyzer is None:
         try:
@@ -455,7 +469,8 @@ async def _gather_context_data(context_data: dict, data_manager: DataSourceManag
 @router.post("/analyze", response_model=ChatResponse)
 async def analyze_financial_data(
     request: ChatRequest,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    x_gemini_api_key: Optional[str] = Header(default=None, alias="X-Gemini-API-Key"),
 ):
     """
     Analyze financial data using AI
@@ -470,7 +485,7 @@ async def analyze_financial_data(
     try:
         # Check if analyzer is available
         try:
-            analyzer = get_analyzer()
+            analyzer = get_analyzer(byok_key=x_gemini_api_key)
         except HTTPException as e:
             # Re-raise HTTP exceptions (like 500 for missing API key)
             raise

--- a/finq-backend/app/api/health_scores.py
+++ b/finq-backend/app/api/health_scores.py
@@ -13,7 +13,7 @@ For Debt/Equity the score is inverted (lower D/E = healthier).
 HealthScore = mean(GrowthScore, NetMarginScore, FCFMarginScore, DebtEquityScore)
 """
 
-from fastapi import APIRouter, HTTPException, Depends, Query
+from fastapi import APIRouter, HTTPException, Depends, Query, Header
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
 from pathlib import Path
@@ -657,7 +657,10 @@ async def get_custom_health_scores(
 # ─────────────────────────────────────────────
 
 @router.post("/report")
-async def generate_health_report(payload: Dict[str, Any]):
+async def generate_health_report(
+    payload: Dict[str, Any],
+    x_gemini_api_key: Optional[str] = Header(default=None, alias="X-Gemini-API-Key"),
+):
     """
     Generate an AI-powered HTML health report for one or multiple tickers.
     Accepts either a single ticker dict, or a dict with `tickers` list.
@@ -735,7 +738,8 @@ Generate the HTML now:
 
     try:
         from app.services.financial_analyzer import FinancialAnalyzer
-        analyzer = FinancialAnalyzer()
+        # Use BYOK key if provided, else fall back to backend default (env)
+        analyzer = FinancialAnalyzer(api_key=x_gemini_api_key or None)
         report = await analyzer.generate_text(prompt)
         # Strip potential markdown tick wrappers
         if report.startswith("```html"):

--- a/finq-flutter/lib/core/api/api_client_dio.dart
+++ b/finq-flutter/lib/core/api/api_client_dio.dart
@@ -9,6 +9,7 @@ class ApiClientDio implements ApiClient {
   ApiClientDio({
     required String baseUrl,
     required AuthService authService,
+    String? geminiApiKey,
     Dio? dio,
     CacheStore? cacheStore,
   })  : _authService = authService,
@@ -27,6 +28,9 @@ class ApiClientDio implements ApiClient {
           final token = await _authService.getIdToken();
           if (token != null && token.isNotEmpty) {
             options.headers['Authorization'] = 'Bearer $token';
+          }
+          if (geminiApiKey != null && geminiApiKey.isNotEmpty) {
+            options.headers['X-Gemini-API-Key'] = geminiApiKey;
           }
           handler.next(options);
         },

--- a/finq-flutter/lib/core/di/providers.dart
+++ b/finq-flutter/lib/core/di/providers.dart
@@ -24,13 +24,22 @@ final baseUrlProvider = StateProvider<String>((ref) {
   return prefs.getString('api_base_url') ?? AppConfig.apiBaseUrl;
 });
 
+/// Provider for User's BYOK Gemini API Key
+final geminiApiKeyProvider = StateProvider<String?>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return prefs.getString('gemini_api_key');
+});
+
 /// API client with caching enabled
 final apiClientProvider = Provider<ApiClient>((ref) {
   final baseUrl = ref.watch(baseUrlProvider);
+  final geminiApiKey = ref.watch(geminiApiKeyProvider);
+
   return ApiClientDio(
     baseUrl: baseUrl,
     authService: ref.read(authServiceProvider),
     cacheStore: ref.read(cacheStoreProvider),
+    geminiApiKey: geminiApiKey,
   );
 });
 

--- a/finq-flutter/lib/features/health/health_page.dart
+++ b/finq-flutter/lib/features/health/health_page.dart
@@ -36,15 +36,15 @@ class HealthPage extends ConsumerWidget {
               unselectedLabelColor: Theme.of(context).colorScheme.onSurfaceVariant,
               indicatorColor: Theme.of(context).colorScheme.primary,
               tabs: const [
-                Tab(text: 'FinQ Suggestions', icon: Icon(Icons.recommend)),
                 Tab(text: 'Custom Health Score', icon: Icon(Icons.settings_suggest)),
+                Tab(text: 'FinQ Suggestions', icon: Icon(Icons.recommend)),
               ],
             ),
             const Expanded(
               child: TabBarView(
                 children: [
-                  HealthScoreTab(),
                   CustomMetricsTab(),
+                  HealthScoreTab(),
                 ],
               ),
             ),

--- a/finq-flutter/lib/features/health/providers/health_providers.dart
+++ b/finq-flutter/lib/features/health/providers/health_providers.dart
@@ -127,6 +127,31 @@ final finqHealthScoreProvider = FutureProvider.family<List<HealthScoreModel>?, S
   return null;
 });
 
+final singleFinqHealthScoreProvider = FutureProvider.family<HealthScoreModel?, String>((ref, ticker) async {
+  if (ticker.isEmpty) return null;
+  final apiClient = ref.watch(apiClientProvider);
+  try {
+    final queryParams = <String, dynamic>{
+      'ticker': ticker,
+      'limit': 1,
+    };
+    final response = await apiClient.get<Map<String, dynamic>>(
+      '/health-scores/finq',
+      queryParameters: queryParams,
+      forceRefresh: true,
+    );
+    if (response.statusCode == 200 && response.data['scores'] != null) {
+      final scores = response.data['scores'] as List;
+      if (scores.isNotEmpty) {
+        return HealthScoreModel.fromJson(scores.first as Map<String, dynamic>);
+      }
+    }
+  } catch (e, st) {
+    print('Error fetching single finq health score for $ticker: $e\n$st');
+  }
+  return null;
+});
+
 final customHealthScoreProvider = FutureProvider.family<List<HealthScoreModel>?, CustomHealthScoreParams>((ref, params) async {
   if (params.metrics.isEmpty) return null;
   if (params.ticker == null && params.category == null) return null;

--- a/finq-flutter/lib/features/health/tabs/custom_metrics_tab.dart
+++ b/finq-flutter/lib/features/health/tabs/custom_metrics_tab.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,15 +29,15 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
   ];
 
   static const _metricExplanations = {
-    'Revenue Growth': 'Measures year-over-year top-line revenue expansion.',
-    'Net Margin': 'Represents the percentage of revenue remaining after all operating expenses.',
-    'FCF Margin': 'Free Cash Flow Margin indicates the proportion of revenue converted into discretionary cash.',
-    'Debt to Equity': 'Evaluates financial leverage by comparing total liabilities to shareholder equity.',
-    'P/E Ratio': 'Price-to-Earnings ratio, a measure of company valuation.',
-    'ROE': "Return on Equity shows how effectively management uses equity to grow the business.",
-    'ROA': "Return on Assets indicates how profitable a company is relative to its total assets.",
-    'Current Ratio': "Measures a company's ability to pay short-term obligations.",
-    'Quick Ratio': "An indicator of a company's short-term liquidity position.",
+    'Revenue Growth': 'Calculation: (Current Revenue - Prev Revenue) / Prev Revenue.\nInterpretation: Ranked against universe. A score > 0.7 makes it a Leader indicating strong top-line momentum.',
+    'Net Margin': 'Calculation: Net Income / Total Revenue.\nInterpretation: Ranked against universe. A score > 0.7 makes it a Leader, showing excellent profitability.',
+    'FCF Margin': 'Calculation: Free Cash Flow / Total Revenue.\nInterpretation: Assesses discretionary cash generation. A score > 0.7 makes it a Leader.',
+    'Debt to Equity': 'Calculation: Total Debt / Shareholder Equity.\nInterpretation: Assesses financial leverage. Ranked inversely. A score > 0.7 means conservative leverage (Leader).',
+    'P/E Ratio': 'Calculation: Price / Earnings.\nInterpretation: Measures valuation. Ranked inversely. A score > 0.7 means attractive valuation (Leader).',
+    'ROE': "Calculation: Net Income / Shareholder Equity.\nInterpretation: Effectiveness of equity use. A score > 0.7 is a Leader.",
+    'ROA': "Calculation: Net Income / Total Assets.\nInterpretation: Return on assets. A score > 0.7 is a Leader.",
+    'Current Ratio': "Calculation: Current Assets / Current Liabilities.\nInterpretation: Short-term liquidity. A score > 0.7 is a Leader.",
+    'Quick Ratio': "Calculation: (Current Assets - Inventory) / Current Liabilities.\nInterpretation: Immediate liquidity. A score > 0.7 is a Leader.",
   };
 
   final _selectedMetrics = <String, double>{
@@ -49,6 +50,7 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
   String _selectedTicker = '';
   bool _shouldCalculate = false;
   bool _isGeneratingReport = false;
+  bool _isGeneratingCustomReport = false;
   Key _dropdownKey = UniqueKey();
 
   @override
@@ -62,7 +64,11 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
       weights: _selectedMetrics.values.toList(),
     );
 
-    final healthScoreAsync = _shouldCalculate && _selectedTicker.isNotEmpty
+    final defaultScoreAsync = _selectedTicker.isNotEmpty
+        ? ref.watch(singleFinqHealthScoreProvider(_selectedTicker))
+        : null;
+
+    final customScoreAsync = _shouldCalculate && _selectedTicker.isNotEmpty
         ? ref.watch(customHealthScoreProvider(queryParams))
         : null;
 
@@ -71,7 +77,7 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Header Card
+          // 1. Header Card
           Card(
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
             child: Padding(
@@ -90,7 +96,7 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          'Select a ticker, choose metrics, assign weights and calculate a custom score.',
+                          'Select a ticker, review its default health, assign custom metric weights, and calculate a tailored score.',
                           style: TextStyle(color: Colors.grey.shade600, fontSize: 13),
                         ),
                       ],
@@ -102,7 +108,7 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
           ),
           const SizedBox(height: 16),
 
-          // Ticker + Weights Config Card
+          // 2. Ticker Search Card
           Card(
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
             child: Padding(
@@ -110,7 +116,6 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Ticker Search
                   const Text('Select Ticker', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
                   const SizedBox(height: 8),
                   SingleTickerSearchAutocomplete(
@@ -122,141 +127,177 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
                       });
                     },
                   ),
-                  const SizedBox(height: 24),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
 
-                  // Weights Header
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text('Metric Weights', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                        decoration: BoxDecoration(
-                          color: isValidWeights ? Colors.green.shade50 : Colors.red.shade50,
-                          border: Border.all(color: isValidWeights ? Colors.green : Colors.red),
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: Text(
-                          'Total: ${(totalWeight * 100).toStringAsFixed(0)}%',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.bold,
-                            color: isValidWeights ? Colors.green.shade700 : Colors.red.shade700,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  if (!isValidWeights) ...[
-                    const SizedBox(height: 8),
-                    Text('Weights must add up to 100%', style: TextStyle(fontSize: 12, color: Colors.red.shade700)),
-                  ],
-                  const SizedBox(height: 16),
+          // 3. Default Score (Shown immediately on ticker selection)
+          if (defaultScoreAsync != null) ...[
+            defaultScoreAsync.when(
+              data: (score) {
+                if (score == null) return const SizedBox.shrink();
+                return _buildScoreCard(score, isCustom: false);
+              },
+              loading: () => const Center(child: Padding(padding: EdgeInsets.all(32), child: CircularProgressIndicator())),
+              error: (err, st) => Text('Error loading dashboard score: $err'),
+            ),
+            const SizedBox(height: 24),
+          ],
 
-                  // Sliders
-                  ..._selectedMetrics.entries.map((entry) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+          // 4. Weights Config Card
+          Card(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Theme(
+                    data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+                    child: ExpansionTile(
+                      initiallyExpanded: true,
+                      tilePadding: EdgeInsets.zero,
+                      title: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Tooltip(
-                                message: _metricExplanations[entry.key] ?? '',
-                                padding: const EdgeInsets.all(12),
-                                margin: const EdgeInsets.symmetric(horizontal: 24),
-                                showDuration: const Duration(seconds: 3),
-                                textStyle: const TextStyle(color: Colors.white, fontSize: 13),
-                                decoration: BoxDecoration(color: Colors.black87, borderRadius: BorderRadius.circular(8)),
-                                child: Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      entry.key,
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w500,
-                                        decoration: TextDecoration.underline,
-                                        decorationStyle: TextDecorationStyle.dotted,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Icon(Icons.info_outline, size: 14, color: Colors.grey.shade600),
-                                  ],
-                                ),
+                          const Text('Adjust Metric Weights', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: isValidWeights ? Colors.green.shade50 : Colors.red.shade50,
+                              border: Border.all(color: isValidWeights ? Colors.green : Colors.red),
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Text(
+                              'Total: ${(totalWeight * 100).toStringAsFixed(0)}%',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: isValidWeights ? Colors.green.shade700 : Colors.red.shade700,
                               ),
-                              Row(children: [
-                                Text('${(entry.value * 100).toStringAsFixed(0)}%',
-                                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
-                                IconButton(
-                                  icon: const Icon(Icons.close, size: 20),
-                                  onPressed: () {
-                                    setState(() {
-                                      _selectedMetrics.remove(entry.key);
-                                      _shouldCalculate = false;
-    
-                                    });
-                                  },
-                                ),
-                              ]),
-                            ],
-                          ),
-                          Slider(
-                            value: entry.value,
-                            min: 0,
-                            max: 1,
-                            divisions: 20,
-                            label: '${(entry.value * 100).toStringAsFixed(0)}%',
-                            onChanged: (value) {
-                              setState(() {
-                                _selectedMetrics[entry.key] = value;
-                              });
-                            },
-                            onChangeEnd: (value) {
-                              final totalW = _selectedMetrics.values.fold(0.0, (s, v) => s + v);
-                              final isValid = (totalW - 1.0).abs() < 0.01;
-                              if (isValid && _selectedTicker.isNotEmpty) {
-                                setState(() {
-                                  ref.invalidate(customHealthScoreProvider(queryParams));
-                                  _shouldCalculate = true;
-
-                                });
-                              } else {
-                                setState(() {
-                                  _shouldCalculate = false;
-
-                                });
-                              }
-                            },
+                            ),
                           ),
                         ],
                       ),
-                    );
-                  }),
-                  const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    key: _dropdownKey,
-                    decoration: const InputDecoration(
-                      labelText: 'Add Metric',
-                      border: OutlineInputBorder(),
+                      children: [
+                        if (!isValidWeights) ...[
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text('Weights must add up to 100%', style: TextStyle(fontSize: 12, color: Colors.red.shade700))
+                          ),
+                        ],
+                        const SizedBox(height: 16),
+      
+                        // Sliders
+                        ..._selectedMetrics.entries.map((entry) {
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Tooltip(
+                                      message: _metricExplanations[entry.key] ?? '',
+                                      padding: const EdgeInsets.all(12),
+                                      margin: const EdgeInsets.symmetric(horizontal: 24),
+                                      showDuration: const Duration(seconds: 3),
+                                      textStyle: const TextStyle(color: Colors.white, fontSize: 13),
+                                      decoration: BoxDecoration(color: Colors.black87, borderRadius: BorderRadius.circular(8)),
+                                      child: Row(
+                                        crossAxisAlignment: CrossAxisAlignment.center,
+                                        children: [
+                                          Text(
+                                            entry.key,
+                                            style: const TextStyle(
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w500,
+                                              decoration: TextDecoration.underline,
+                                              decorationStyle: TextDecorationStyle.dotted,
+                                            ),
+                                          ),
+                                          const SizedBox(width: 4),
+                                          Icon(Icons.info_outline, size: 14, color: Colors.grey.shade600),
+                                        ],
+                                      ),
+                                    ),
+                                    Row(children: [
+                                      Text('${(entry.value * 100).toStringAsFixed(0)}%',
+                                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
+                                      IconButton(
+                                        icon: const Icon(Icons.close, size: 20),
+                                        onPressed: () {
+                                          setState(() {
+                                            _selectedMetrics.remove(entry.key);
+                                            _shouldCalculate = false;
+                                          });
+                                        },
+                                      ),
+                                    ]),
+                                  ],
+                                ),
+                                Slider(
+                                  value: entry.value,
+                                  min: 0,
+                                  max: 1,
+                                  divisions: 20,
+                                  label: '${(entry.value * 100).toStringAsFixed(0)}%',
+                                  onChanged: (value) {
+                                    setState(() {
+                                      _selectedMetrics[entry.key] = value;
+                                    });
+                                  },
+                                  onChangeEnd: (value) {
+                                    final totalW = _selectedMetrics.values.fold(0.0, (s, v) => s + v);
+                                    final isValid = (totalW - 1.0).abs() < 0.01;
+                                    if (isValid && _selectedTicker.isNotEmpty) {
+                                      setState(() {
+                                        ref.invalidate(customHealthScoreProvider(queryParams));
+                                        _shouldCalculate = true;
+                                      });
+                                    } else {
+                                      setState(() {
+                                        _shouldCalculate = false;
+                                      });
+                                    }
+                                  },
+                                ),
+                              ],
+                            ),
+                          );
+                        }),
+                        const SizedBox(height: 8),
+                        DropdownButtonFormField<String>(
+                          key: _dropdownKey,
+                          decoration: const InputDecoration(
+                            labelText: 'Add Metric',
+                            border: OutlineInputBorder(),
+                          ),
+                          items: _availableMetrics
+                              .where((m) => !_selectedMetrics.containsKey(m))
+                              .map((metric) => DropdownMenuItem(value: metric, child: Text(metric)))
+                              .toList(),
+                          onChanged: (value) {
+                            if (value != null) {
+                              setState(() {
+                                _dropdownKey = UniqueKey();
+                                _selectedMetrics[value] = 0.1;
+                                _shouldCalculate = false;
+                              });
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                      ],
                     ),
-                    items: _availableMetrics
-                        .where((m) => !_selectedMetrics.containsKey(m))
-                        .map((metric) => DropdownMenuItem(value: metric, child: Text(metric)))
-                        .toList(),
-                    onChanged: (value) {
-                      if (value != null) {
-                        setState(() {
-                          _dropdownKey = UniqueKey();
-                          _selectedMetrics[value] = 0.1;
-                          _shouldCalculate = false;
-                        });
-                      }
-                    },
                   ),
-                  const SizedBox(height: 24),
+
+                  // Calculate Button
+                  const SizedBox(height: 8),
                   SizedBox(
                     width: double.infinity,
                     height: 52,
@@ -292,238 +333,298 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
             ),
           ),
 
-          const SizedBox(height: 16),
-
-          // Results
-          if (_shouldCalculate && _selectedTicker.isNotEmpty && healthScoreAsync != null)
-            healthScoreAsync.when(
+          // 5. Custom Score (if computed)
+          if (customScoreAsync != null && _shouldCalculate) ...[
+            customScoreAsync.when(
               data: (scores) {
                 if (scores == null || scores.isEmpty) {
                   return const Padding(
                     padding: EdgeInsets.all(32),
-                    child: Center(child: Text('No data available for this ticker / metric combination.')),
+                    child: Center(child: Text('No custom data available for this ticker/metrics.')),
                   );
                 }
-                final score = scores.first;
-                final hScore = score.healthScore ?? 0.0;
-                final hScorePct = (hScore * 100).toStringAsFixed(1);
-                final hColor = _getScoreColor(hScore);
-                final hLabel = _getScoreLabel(hScore);
-
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Score Card
-                    Card(
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      child: Padding(
-                        padding: const EdgeInsets.all(24),
-                        child: Column(
-                          children: [
-                            Text(
-                              'Custom Health Score – ${score.ticker}',
-                              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center,
-                            ),
-                            const SizedBox(height: 16),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Container(
-                                  width: 80,
-                                  height: 80,
-                                  decoration: BoxDecoration(
-                                    shape: BoxShape.circle,
-                                    border: Border.all(color: hColor, width: 5),
-                                  ),
-                                  child: Center(
-                                    child: Text(
-                                      '$hScorePct%',
-                                      style: TextStyle(
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.bold,
-                                        color: hColor,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(width: 16),
-                                Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(hLabel, style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: hColor)),
-                                    if (score.insight != null && score.insight!.isNotEmpty)
-                                      SizedBox(
-                                        width: 300,
-                                        child: Text(
-                                          score.insight!,
-                                          style: TextStyle(fontSize: 12, color: Colors.grey.shade600, fontStyle: FontStyle.italic),
-                                          maxLines: 3,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 24),
-                            // Metric Highlights Grid
-                            GridView.count(
-                              shrinkWrap: true,
-                              physics: const NeverScrollableScrollPhysics(),
-                              crossAxisCount: 2,
-                              mainAxisSpacing: 12,
-                              crossAxisSpacing: 12,
-                              childAspectRatio: 2.2,
-                              children: _selectedMetrics.keys.map((metric) {
-                                final val = score.rawMetrics[metric];
-                                return Container(
-                                  padding: const EdgeInsets.all(12),
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
-                                    borderRadius: BorderRadius.circular(8),
-                                    border: Border.all(color: Theme.of(context).colorScheme.outlineVariant.withOpacity(0.5)),
-                                  ),
-                                  child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Text(
-                                        metric,
-                                        style: TextStyle(fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant, fontWeight: FontWeight.bold),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                      const SizedBox(height: 4),
-                                      Text(
-                                        val != null ? _formatRawMetric(metric, val) : 'N/A',
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                                      ),
-                                    ],
-                                  ),
-                                );
-                              }).toList(),
-                            ),
-                            const SizedBox(height: 24),
-                            const Divider(),
-                            const SizedBox(height: 16),
-                            const Text(
-                              'Detailed Rankings',
-                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold, color: Colors.grey),
-                            ),
-                            const SizedBox(height: 12),
-                            // Metric Bars
-                            ..._selectedMetrics.keys.map((metric) {
-                              final metricScore = score.metricScores[metric] ?? 0.0;
-                              return Padding(
-                                padding: const EdgeInsets.only(bottom: 12),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        Text(metric, style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500)),
-                                        Row(
-                                          children: [
-                                            if (score.rawMetrics.containsKey(metric) && score.rawMetrics[metric] != null)
-                                              Text(
-                                                _formatRawMetric(metric, score.rawMetrics[metric]!),
-                                                style: TextStyle(fontSize: 13, color: Theme.of(context).colorScheme.onSurfaceVariant),
-                                              ),
-                                            const SizedBox(width: 8),
-                                            Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                                              decoration: BoxDecoration(
-                                                color: _getScoreColor(metricScore).withOpacity(0.1),
-                                                borderRadius: BorderRadius.circular(4),
-                                              ),
-                                              child: Text('Rank: ${(metricScore * 100).toStringAsFixed(0)}%',
-                                                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.bold, color: _getScoreColor(metricScore))),
-                                            ),
-                                          ],
-                                        ),
-                                      ],
-                                    ),
-                                    const SizedBox(height: 6),
-                                    LinearProgressIndicator(
-                                      value: metricScore.clamp(0.0, 1.0),
-                                      backgroundColor: Colors.grey.shade200,
-                                      valueColor: AlwaysStoppedAnimation<Color>(_getScoreColor(metricScore)),
-                                      minHeight: 8,
-                                    ),
-                                  ],
-                                ),
-                              );
-                            }),
-                            const SizedBox(height: 20),
-                            // Generate Report Button
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: OutlinedButton.icon(
-                                    onPressed: _isGeneratingReport ? null : () => _generateReport(score),
-                                    icon: _isGeneratingReport
-                                        ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
-                                        : const Icon(Icons.description_outlined),
-                                    label: Text(_isGeneratingReport ? 'Generating...' : 'Generate Health Report'),
-                                    style: OutlinedButton.styleFrom(
-                                      foregroundColor: Colors.blue.shade700,
-                                      side: BorderSide(color: Colors.blue.shade700),
-                                      padding: const EdgeInsets.symmetric(vertical: 14),
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                IconButton(
-                                  icon: const Icon(Icons.refresh, color: Colors.amber),
-                                  tooltip: 'Refresh & Regen',
-                                  onPressed: _isGeneratingReport ? null : () => _refreshAndGenerateReport(score),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    // Report display removed — report opens in a new browser tab via HtmlExportService
-                  ],
-                );
+                return _buildScoreCard(scores.first, isCustom: true);
               },
-              loading: () => const Padding(
-                padding: EdgeInsets.all(48),
-                child: Center(child: CircularProgressIndicator()),
-              ),
+              loading: () => const Center(child: Padding(padding: EdgeInsets.all(32), child: CircularProgressIndicator())),
               error: (err, st) => Padding(
                 padding: const EdgeInsets.all(32),
                 child: Center(child: Text('Error: $err', style: const TextStyle(color: Colors.red))),
               ),
             ),
+          ],
+          
+          if (_selectedTicker.isNotEmpty) const SizedBox(height: 60),
         ],
       ),
     );
   }
 
-  Future<void> _generateReport(dynamic score) async {
-    setState(() => _isGeneratingReport = true);
+  Widget _buildScoreCard(HealthScoreModel score, {required bool isCustom}) {
+    final hScore = score.healthScore ?? 0.0;
+    final hScorePct = (hScore * 100).toStringAsFixed(1);
+    final hColor = _getScoreColor(hScore, isInverse: false);
+    final hLabel = _getScoreLabel(hScore);
+
+    final title = isCustom ? 'Custom Health Score – ${score.ticker}' : 'Default FinQ Health Score – ${score.ticker}';
+    final cardColor = isCustom ? Theme.of(context).colorScheme.surface : Theme.of(context).colorScheme.surfaceContainerLow;
+
+    final metricsToShow = isCustom
+        ? _selectedMetrics.keys.toList()
+        : ['Revenue Growth', 'Net Margin', 'FCF Margin', 'Debt to Equity', 'P/E Ratio'];
+
+    final isGenerating = _isGeneratingReport && _isGeneratingCustomReport == isCustom;
+    
+    // Responsive grid counting
+    final screenWidth = MediaQuery.of(context).size.width;
+    int crossAxisCount = 2; // Mobile
+    if (screenWidth > 1200) {
+      crossAxisCount = 5; // Large Desktop
+    } else if (screenWidth > 900) {
+      crossAxisCount = 4; // Desktop
+    } else if (screenWidth > 600) {
+      crossAxisCount = 3; // Tablet
+    }
+
+    return Card(
+      color: cardColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: isCustom ? BorderSide(color: Colors.blue.shade200, width: 2) : BorderSide.none,
+      ),
+      elevation: isCustom ? 4 : 1,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(color: hColor, width: 5),
+                    color: Theme.of(context).colorScheme.surface,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '$hScorePct%',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: hColor,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(hLabel, style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: hColor)),
+                      if (score.insight != null && score.insight!.isNotEmpty)
+                        Text(
+                          score.insight!,
+                          style: TextStyle(fontSize: 12, color: Colors.grey.shade600, fontStyle: FontStyle.italic),
+                          maxLines: 4,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            // Metric Highlights Grid (KPI Cards with Gauges)
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: crossAxisCount,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: 2.8, // Ultra-wide to match reference image
+              ),
+              itemCount: metricsToShow.length,
+              itemBuilder: (context, index) {
+                final metric = metricsToShow[index];
+                final val = _getRawMetricValue(score, metric);
+                final metricScore = _getMetricRankValue(score, metric) ?? 0.0;
+                
+                final isInverse = metric == 'Debt to Equity' || metric == 'P/E Ratio';
+                final interp = _getInterpretation(metricScore, isInverse: isInverse);
+                final interpColor = _getScoreColor(metricScore, isInverse: false); // Percentile is ALREADY inverted in backend
+
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Theme.of(context).colorScheme.outlineVariant.withOpacity(0.5)),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      // Header Row
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Flexible(
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(
+                                metric,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                maxLines: 1,
+                              ),
+                            ),
+                          ),
+                          Tooltip(
+                            message: _metricExplanations[metric] ?? '',
+                            padding: const EdgeInsets.all(12),
+                            margin: const EdgeInsets.symmetric(horizontal: 24),
+                            showDuration: const Duration(seconds: 4),
+                            textStyle: const TextStyle(color: Colors.white, fontSize: 13),
+                            decoration: BoxDecoration(color: Colors.black87, borderRadius: BorderRadius.circular(8)),
+                            child: Icon(Icons.info_outline, size: 14, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                          ),
+                        ],
+                      ),
+                      
+                      // Progress Bar + Value + Interpretation Row
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                flex: 2,
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(4),
+                                  child: LinearProgressIndicator(
+                                    value: metricScore.clamp(0.0, 1.0),
+                                    backgroundColor: Colors.grey.withOpacity(0.2),
+                                    valueColor: AlwaysStoppedAnimation<Color>(interpColor),
+                                    minHeight: 6,
+                                  ),
+                                ),
+                              ),
+                              const Spacer(flex: 1), // Only take up partial width for the bar
+                            ],
+                          ),
+                          const SizedBox(height: 6),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Text(
+                                val != null ? _formatRawMetric(metric, val) : 'N/A',
+                                style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold, height: 1.0),
+                              ),
+                              const Spacer(),
+                              Text(
+                                interp,
+                                style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: interpColor, height: 1.0),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+
+            // Generate Report Button
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _isGeneratingReport ? null : () => _generateReport(score, isCustom: isCustom),
+                    icon: isGenerating
+                        ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Icon(Icons.description_outlined),
+                    label: Text(isGenerating ? 'Generating...' : 'Generate ${isCustom ? "Custom " : "Default "}Report'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.blue.shade700,
+                      side: BorderSide(color: Colors.blue.shade700),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IconButton(
+                  icon: const Icon(Icons.refresh, color: Colors.amber),
+                  tooltip: 'Refresh & Regen',
+                  onPressed: _isGeneratingReport ? null : () => _refreshAndGenerateReport(score, isCustom: isCustom),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double? _getRawMetricValue(HealthScoreModel score, String metric) {
+    if (score.rawMetrics.containsKey(metric)) return score.rawMetrics[metric];
+    switch (metric) {
+      case 'Revenue Growth': return score.rawMetrics['Growth'];
+      case 'Net Margin': return score.rawMetrics['NetMargin'];
+      case 'FCF Margin': return score.rawMetrics['FCFMargin'];
+      case 'Debt to Equity': return score.rawMetrics['DebtEquity'];
+      case 'P/E Ratio': return score.rawMetrics['PE'];
+    }
+    return null;
+  }
+
+  double? _getMetricRankValue(HealthScoreModel score, String metric) {
+    if (score.metricScores.containsKey(metric)) return score.metricScores[metric];
+    switch (metric) {
+      case 'Revenue Growth': return score.metricScores['Growth'];
+      case 'Net Margin': return score.metricScores['NetMargin'];
+      case 'FCF Margin': return score.metricScores['FCFMargin'];
+      case 'Debt to Equity': return score.metricScores['DebtEquity'];
+      case 'P/E Ratio': return score.metricScores['PE'];
+    }
+    return null;
+  }
+
+  Future<void> _generateReport(HealthScoreModel score, {required bool isCustom}) async {
+    setState(() {
+      _isGeneratingReport = true;
+      _isGeneratingCustomReport = isCustom;
+    });
 
     try {
       final payload = <String, dynamic>{
         'ticker': score.ticker,
         'healthScore': score.healthScore,
-        'growth': score.growth,
-        'netMargin': score.netMargin,
-        'fcfMargin': score.fcfMargin,
-        'debtEquity': score.debtEquity,
-        'growthScore': score.growthScore,
-        'netMarginScore': score.netMarginScore,
-        'fcfMarginScore': score.fcfMarginScore,
-        'debtEquityScore': score.debtEquityScore,
+        'growth': score.growth ?? _getRawMetricValue(score, 'Revenue Growth'),
+        'netMargin': score.netMargin ?? _getRawMetricValue(score, 'Net Margin'),
+        'fcfMargin': score.fcfMargin ?? _getRawMetricValue(score, 'FCF Margin'),
+        'debtEquity': score.debtEquity ?? _getRawMetricValue(score, 'Debt to Equity'),
+        'peRatio': score.peRatio ?? _getRawMetricValue(score, 'P/E Ratio'),
         'insight': score.insight,
-        ...score.rawMetrics, // Include all raw metrics (P/E, ROA, etc.)
-        'customWeights': Map<String, double>.from(
-          Map.fromIterables(_selectedMetrics.keys, _selectedMetrics.values),
-        ),
+        ...score.rawMetrics,
+        'customWeights': isCustom 
+           ? Map<String, double>.from(Map.fromIterables(_selectedMetrics.keys, _selectedMetrics.values)) 
+           : null,
       };
       await HtmlExportService.generateAndOpenReport(
         htmlGenerator: () async {
@@ -531,7 +632,7 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
           if (result == null) throw Exception('Failed to generate report');
           return result;
         },
-        filenamePrefix: score.ticker,
+        filenamePrefix: '${score.ticker}_${isCustom ? "custom_" : ""}health_report',
       );
     } catch (e) {
       if (mounted) {
@@ -540,17 +641,22 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isGeneratingReport = false);
+      if (mounted) setState(() {
+         _isGeneratingReport = false;
+      });
     }
   }
 
-  Future<void> _refreshAndGenerateReport(dynamic score) async {
+  Future<void> _refreshAndGenerateReport(HealthScoreModel score, {required bool isCustom}) async {
     await ReportCacheService.deleteReport([score.ticker]);
-    return _generateReport(score);
+    return _generateReport(score, isCustom: isCustom);
   }
 
-
-  Color _getScoreColor(double score) {
+  Color _getScoreColor(double score, {bool isInverse = false}) {
+    // Note: The backend already inverts the percentile rank for DebtEquity and PE. 
+    // So a higher `score` (percentile rank) is ALWAYS better, even for inverted metrics.
+    // E.g., a low Debt/Equity becomes a 0.9 rank (Green). 
+    // We do not need to flip colors.
     if (score >= 0.7) return Colors.green;
     if (score >= 0.4) return Colors.amber.shade600;
     return Colors.red;
@@ -562,20 +668,31 @@ class _CustomMetricsTabState extends ConsumerState<CustomMetricsTab> {
     return 'Weak';
   }
 
+  String _getInterpretation(double score, {bool isInverse = false}) {
+    // The backend already converted low Debt/Equity into a HIGH percentile score (0.9 rank).
+    // Therefore, a score >= 0.7 is always a "Leader", regardless of if it's inverse.
+    if (score >= 0.7) {
+      if (isInverse) return "Leader (Low is Good)";
+      return 'Leader';
+    }
+    if (score >= 0.4) return 'Neutral';
+    
+    if (isInverse) return "Lagger (High is Bad)";
+    return 'Lagger';
+  }
+
   String _formatRawMetric(String metricName, double value) {
     final lowerName = metricName.toLowerCase();
-    // P/E Ratio is a multiplier (e.g. 28.5x), not a percentage
     if (lowerName.contains('p/e') || lowerName.contains('pe ratio')) {
       return '${value.toStringAsFixed(1)}x';
     }
-    // Percentage-type metrics
     if (lowerName.contains('margin') ||
         lowerName.contains('growth') ||
         lowerName.contains('roe') ||
         lowerName.contains('roa')) {
       return '${(value * 100).toStringAsFixed(2)}%';
     }
-    // E.g., Debt/Equity, Current Ratio, Quick Ratio
     return value.toStringAsFixed(2);
   }
 }
+// Custom Painters removed in favor of LinearProgressIndicator

--- a/finq-flutter/lib/features/settings/settings_page.dart
+++ b/finq-flutter/lib/features/settings/settings_page.dart
@@ -65,7 +65,9 @@ class _PreferencesSection extends ConsumerWidget {
     return Card(
       child: Column(
         children: [
-          _ConnectionSettingsTile(),
+          const _ConnectionSettingsTile(),
+          const Divider(height: 1),
+          const _GeminiKeySettingsTile(),
           const Divider(height: 1),
           // --- Dark Mode Toggle ---
           Padding(
@@ -477,6 +479,102 @@ class _ConnectionSettingsTile extends ConsumerWidget {
                   Navigator.of(context).pop();
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('API URL updated')),
+                  );
+                }
+              }
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GeminiKeySettingsTile extends ConsumerWidget {
+  const _GeminiKeySettingsTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final apiKey = ref.watch(geminiApiKeyProvider);
+    final isSet = apiKey != null && apiKey.isNotEmpty;
+    
+    return ListTile(
+      leading: const Icon(Icons.key),
+      title: const Text('Gemini API Key (BYOK)'),
+      subtitle: Text(
+        isSet ? 'Key configured (••••${apiKey.substring(apiKey.length >= 4 ? apiKey.length - 4 : 0)})' : 'Not configured. Using default backend key.',
+        style: TextStyle(color: isSet ? Colors.green.shade700 : Colors.grey),
+      ),
+      trailing: const Icon(Icons.edit),
+      onTap: () => _showEditDialog(context, ref, apiKey ?? ''),
+    );
+  }
+
+  void _showEditDialog(BuildContext context, WidgetRef ref, String currentKey) {
+    final controller = TextEditingController(text: currentKey);
+    
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Gemini API Key'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: controller,
+              decoration: const InputDecoration(
+                labelText: 'API Key',
+                hintText: 'AIzaSy...',
+                border: OutlineInputBorder(),
+              ),
+              obscureText: true,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Your key is securely stored on this device. It will be injected into FinQChat and Health Reports.',
+              style: TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () async {
+              // Reset to default (clear preference)
+              final prefs = ref.read(sharedPreferencesProvider);
+              await prefs.remove('gemini_api_key');
+              ref.invalidate(geminiApiKeyProvider);
+              
+              if (context.mounted) {
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Removed custom Gemini API key')),
+                );
+              }
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Clear'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final newKey = controller.text.trim();
+              if (newKey.isNotEmpty) {
+                // Update provider state
+                ref.read(geminiApiKeyProvider.notifier).state = newKey;
+                
+                // Persist to SharedPreferences
+                final prefs = ref.read(sharedPreferencesProvider);
+                await prefs.setString('gemini_api_key', newKey);
+                
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Gemini API Key saved')),
                   );
                 }
               }


### PR DESCRIPTION
Phase 5 - Custom Health Score UI:
- Reorder Health tabs: Custom Health Score tab is now first
- Add Default FinQ Health Score panel to Custom tab (auto-loads on ticker select)
- Display concise KPI metric cards with linear progress indicators
- Add collapsible Adjust Metric Weights panel (ExpansionTile)
- Add Leader/Neutral/Lagger interpretation labels per metric
- Add tooltip info buttons per KPI card

Phase 6 - Bring Your Own Key (BYOK):
- Add geminiApiKeyProvider backed by SharedPreferences
- Inject X-Gemini-API-Key header via Dio interceptor in ApiClientDio
- Add _GeminiKeySettingsTile in SettingsPage with secure dialog (save/clear)
- FastAPI /chat/analyze: accept X-Gemini-API-Key header, per-request FinancialAnalyzer
- FastAPI /health-scores/report: accept X-Gemini-API-Key header, pass to FinancialAnalyzer