### PR TITLE
feat: migrate fundamentals from parquet to neon postgres

### DIFF
--- a/finq-backend/alembic/env.py
+++ b/finq-backend/alembic/env.py
@@ -13,6 +13,7 @@ from app.models import (  # noqa: F401 — side-effect imports register metadata
     Friend, FriendStatus,
     User,
     ChatSession, ChatMessage,
+    Fundamental,
 )
 from app.config import settings
 

--- a/finq-backend/alembic/versions/c3d4e5f6a7b8_add_fundamentals_table.py
+++ b/finq-backend/alembic/versions/c3d4e5f6a7b8_add_fundamentals_table.py
@@ -1,0 +1,58 @@
+"""add_fundamentals_table
+
+Revision ID: c3d4e5f6a7b8
+Revises: 13e00d3ad29d
+Create Date: 2026-04-04 00:00:00.000000
+
+Migrates financial fundamentals data from fundamentals_tall.parquet
+into a proper PostgreSQL table for reliable cloud deployments.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "13e00d3ad29d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fundamentals",
+        # Surrogate PK — composite string: ticker|fiscal_period|metric|category
+        sa.Column("id", sa.String(512), primary_key=True, nullable=False),
+        sa.Column("ticker", sa.String(20), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=True),
+        sa.Column("fiscal_period", sa.String(10), nullable=False),
+        sa.Column("metric", sa.String(255), nullable=False),
+        sa.Column("category", sa.String(50), nullable=False),
+        sa.Column("value", sa.Float(), nullable=True),
+        # Unique business key constraint
+        sa.UniqueConstraint(
+            "ticker", "fiscal_period", "metric", "category",
+            name="uq_fundamentals_row",
+        ),
+    )
+    # Indexes for fast lookups
+    op.create_index(
+        "ix_fundamentals_ticker",
+        "fundamentals",
+        ["ticker"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_fundamentals_ticker_period",
+        "fundamentals",
+        ["ticker", "fiscal_period"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_fundamentals_ticker_period", table_name="fundamentals")
+    op.drop_index("ix_fundamentals_ticker", table_name="fundamentals")
+    op.drop_table("fundamentals")

--- a/finq-backend/app/models/__init__.py
+++ b/finq-backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.post import Post, PostLike, PostComment
 from app.models.friend import Friend, FriendStatus
 from app.models.user import User
 from app.models.chat import ChatSession, ChatMessage
+from app.models.fundamentals import Fundamental
 
 __all__ = [
     "Base",
@@ -19,4 +20,5 @@ __all__ = [
     "User",
     "ChatSession",
     "ChatMessage",
+    "Fundamental",
 ]

--- a/finq-backend/app/models/fundamentals.py
+++ b/finq-backend/app/models/fundamentals.py
@@ -1,0 +1,49 @@
+"""
+SQLAlchemy model for financial fundamentals (migrated from parquet).
+
+Schema mirrors the long/tall format of fundamentals_tall.parquet:
+  Ticker | PeriodEnd | FiscalPeriod | Metric | Category | Value
+"""
+from sqlalchemy import (
+    Column, String, Float, Date, Index, UniqueConstraint
+)
+from app.database import Base
+
+
+class Fundamental(Base):
+    __tablename__ = "fundamentals"
+
+    # ── Columns ──────────────────────────────────────────────────────────────
+    ticker: str = Column(String(20), nullable=False)
+    period_end = Column(Date, nullable=True)
+    fiscal_period: str = Column(String(10), nullable=False)   # e.g. "2024Q3"
+    metric: str = Column(String(255), nullable=False)
+    category: str = Column(String(50), nullable=False)        # IncomeStatement | BalanceSheet | CashFlow
+    value = Column(Float, nullable=True)
+
+    # ── Composite primary key ─────────────────────────────────────────────────
+    __table_args__ = (
+        UniqueConstraint(
+            "ticker", "fiscal_period", "metric", "category",
+            name="uq_fundamentals_row",
+        ),
+        # Fast lookup by ticker (the primary query path)
+        Index("ix_fundamentals_ticker", "ticker"),
+        # Allows efficient "latest N periods for ticker" queries
+        Index("ix_fundamentals_ticker_period", "ticker", "fiscal_period"),
+        # Synthetic PK so SQLAlchemy / Alembic are happy
+        {"extend_existing": True},
+    )
+
+    # SQLAlchemy requires exactly one primary key column; use a surrogate.
+    id = Column(
+        String(512),   # ticker|fiscal_period|metric|category
+        primary_key=True,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Fundamental ticker={self.ticker} period={self.fiscal_period} "
+            f"metric={self.metric} value={self.value}>"
+        )

--- a/finq-backend/app/services/data_pipeline.py
+++ b/finq-backend/app/services/data_pipeline.py
@@ -1,361 +1,337 @@
 """
-Data Pipeline Service for fetching and updating financial fundamentals data
+Data Pipeline Service — writes fundamentals to PostgreSQL instead of parquet.
+
+All data fetched via Yahoo Finance is upserted into the `fundamentals` table,
+making the parquet file completely optional for local dev and irrelevant in
+production (Render / Railway).
 """
-import pandas as pd
-import yfinance as yf
 import logging
-from pathlib import Path
-from typing import List, Dict, Optional
-from datetime import datetime, timedelta
 import time
+from typing import List, Dict, Optional
+
+import pandas as pd
+import sqlalchemy as sa
+import yfinance as yf
 from app.config import settings
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Row-ID helper (must match seed_fundamentals.py and the model definition)
+# ---------------------------------------------------------------------------
+
+def _make_row_id(ticker: str, fiscal_period: str, metric: str, category: str) -> str:
+    return f"{ticker}|{fiscal_period}|{metric}|{category}"
+
+
+# ---------------------------------------------------------------------------
+# DataPipeline
+# ---------------------------------------------------------------------------
 
 class DataPipeline:
-    """Service for fetching and updating fundamentals data"""
-    
-    def __init__(self):
-        self.fundamentals_path = self._find_fundamentals_file()
-    
-    def _find_fundamentals_file(self) -> Optional[Path]:
-        """Find the fundamentals parquet file"""
-        # Railway runs from finq-backend/, so check current directory first
-        # Priority: Railway volume > env var > current directory > project root
-        possible_paths = [
-            Path("/data/fundamentals_tall.parquet"),  # Railway volume (persistent)
-            Path(settings.fundamentals_path),  # From environment variable
-            Path("fundamentals_tall.parquet"),  # Current directory (finq-backend/)
-            Path(__file__).parent.parent.parent.parent / settings.fundamentals_path,
-            Path(__file__).parent.parent.parent.parent / "fundamentals_tall.parquet",
-            Path("../fundamentals_tall.parquet"),
-        ]
-        
-        for path in possible_paths:
-            if path.exists():
-                logger.info(f"Found fundamentals file at {path}")
-                return path
-        
-        logger.warning(f"Fundamentals file not found. Tried: {possible_paths}")
-        return None
-    
-    def _get_existing_data(self) -> pd.DataFrame:
-        """Load existing fundamentals data"""
-        if not self.fundamentals_path or not self.fundamentals_path.exists():
-            return pd.DataFrame()
-        
-        try:
-            df = pd.read_parquet(self.fundamentals_path)
-            logger.info(f"Loaded {len(df)} existing rows from {self.fundamentals_path}")
-            return df
-        except Exception as e:
-            logger.error(f"Error loading existing data: {e}")
-            return pd.DataFrame()
-    
-    def _melt_quarterly_data(self, df: pd.DataFrame, ticker: str, category: str) -> pd.DataFrame:
+    """Service for fetching and updating fundamentals data in PostgreSQL."""
+
+    # ------------------------------------------------------------------
+    # Internal: Yahoo Finance → long-format DataFrame
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _melt_quarterly_data(
+        df: pd.DataFrame, ticker: str, category: str
+    ) -> pd.DataFrame:
         """
-        Convert quarterly financial statements to long format
-        Based on build_fundamentals_tall.py logic
-        
-        Args:
-            df: DataFrame with quarterly data (columns are dates, rows are metrics)
-            ticker: Ticker symbol
-            category: Category name (IncomeStatement, BalanceSheet, CashFlow)
-        
-        Returns:
-            DataFrame in long format with columns: Ticker, FiscalPeriod, Metric, Value, Category, PeriodEnd
+        Convert a quarterly financial statement (wide format, columns = dates)
+        into the tall/long format used by the `fundamentals` table.
         """
         if df is None or df.empty:
             return pd.DataFrame()
-        
-        # Convert columns to datetime if needed
+
+        # Ensure columns are Timestamps
         cols = []
         for c in df.columns:
             try:
                 cols.append(pd.to_datetime(c))
             except (ValueError, TypeError):
                 cols.append(pd.NaT)
+        df = df.copy()
         df.columns = cols
-        df = df.dropna(axis=1, how='all')
-        
+        df = df.dropna(axis=1, how="all")
+
         records = []
         for metric, row in df.iterrows():
             for period_end, value in row.items():
                 if pd.isna(period_end):
                     continue
-                
-                # Convert to quarter label (e.g., "2025Q1")
                 quarter = f"{period_end.year}Q{(period_end.month - 1) // 3 + 1}"
-                
-                records.append({
-                    'Ticker': ticker,
-                    'PeriodEnd': period_end.date() if isinstance(period_end, pd.Timestamp) else None,
-                    'FiscalPeriod': quarter,
-                    'Metric': metric,
-                    'Category': category,
-                    'Value': float(value) if pd.notna(value) else 0.0,
-                })
-        
+                records.append(
+                    {
+                        "ticker": str(ticker).upper(),
+                        "period_end": period_end.date()
+                        if isinstance(period_end, pd.Timestamp)
+                        else None,
+                        "fiscal_period": quarter,
+                        "metric": str(metric),
+                        "category": category,
+                        "value": float(value) if pd.notna(value) else None,
+                    }
+                )
         return pd.DataFrame(records)
-    
+
     async def fetch_ticker_quarterly(self, ticker: str) -> pd.DataFrame:
-        """
-        Fetch latest quarterly financial data for a ticker from Yahoo Finance
-        
-        Args:
-            ticker: Stock ticker symbol
-        
-        Returns:
-            DataFrame with quarterly data in long format
-        """
+        """Fetch latest quarterly financials from Yahoo Finance."""
         try:
-            stock = yf.Ticker(ticker)
-            
-            all_records = []
-            
-            # Fetch Income Statement
-            try:
-                income_stmt = stock.quarterly_financials
-                if income_stmt is not None and not income_stmt.empty:
-                    income_melted = self._melt_quarterly_data(income_stmt, ticker, 'IncomeStatement')
-                    all_records.append(income_melted)
-                    logger.info(f"Fetched {len(income_melted)} income statement records for {ticker}")
-            except Exception as e:
-                logger.warning(f"Error fetching income statement for {ticker}: {e}")
-            
-            # Fetch Balance Sheet
-            try:
-                balance_sheet = stock.quarterly_balance_sheet
-                if balance_sheet is not None and not balance_sheet.empty:
-                    balance_melted = self._melt_quarterly_data(balance_sheet, ticker, 'BalanceSheet')
-                    all_records.append(balance_melted)
-                    logger.info(f"Fetched {len(balance_melted)} balance sheet records for {ticker}")
-            except Exception as e:
-                logger.warning(f"Error fetching balance sheet for {ticker}: {e}")
-            
-            # Fetch Cash Flow
-            try:
-                cashflow = stock.quarterly_cashflow
-                if cashflow is not None and not cashflow.empty:
-                    cashflow_melted = self._melt_quarterly_data(cashflow, ticker, 'CashFlow')
-                    all_records.append(cashflow_melted)
-                    logger.info(f"Fetched {len(cashflow_melted)} cash flow records for {ticker}")
-            except Exception as e:
-                logger.warning(f"Error fetching cash flow for {ticker}: {e}")
-            
+            stock = yf.Ticker(ticker.upper())
+            all_records: list[pd.DataFrame] = []
+
+            for attr, cat in [
+                ("quarterly_financials", "IncomeStatement"),
+                ("quarterly_balance_sheet", "BalanceSheet"),
+                ("quarterly_cashflow", "CashFlow"),
+            ]:
+                try:
+                    raw = getattr(stock, attr)
+                    if raw is not None and not raw.empty:
+                        melted = self._melt_quarterly_data(raw, ticker, cat)
+                        all_records.append(melted)
+                        logger.info(
+                            f"Fetched {len(melted)} {cat} records for {ticker}"
+                        )
+                except Exception as exc:
+                    logger.warning(f"Error fetching {cat} for {ticker}: {exc}")
+
             if all_records:
                 result = pd.concat(all_records, ignore_index=True)
                 logger.info(f"Total records fetched for {ticker}: {len(result)}")
                 return result
-            else:
-                logger.warning(f"No data fetched for {ticker}")
-                return pd.DataFrame()
-                
-        except Exception as e:
-            logger.error(f"Error fetching quarterly data for {ticker}: {e}")
+
+            logger.warning(f"No data fetched for {ticker}")
             return pd.DataFrame()
-    
-    async def update_ticker_data(self, ticker: str, force_refresh: bool = False) -> Dict:
+
+        except Exception as exc:
+            logger.error(f"Error fetching quarterly data for {ticker}: {exc}")
+            return pd.DataFrame()
+
+    # ------------------------------------------------------------------
+    # Internal: upsert a DataFrame into the fundamentals table
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _upsert_to_db(df: pd.DataFrame) -> int:
         """
-        Update fundamentals data for a specific ticker
-        
-        Args:
-            ticker: Stock ticker symbol
-            force_refresh: If True, replace all data for this ticker. If False, merge new data.
-        
-        Returns:
-            Dict with update status and statistics
+        Bulk-upsert rows into the `fundamentals` table.
+        Returns the number of rows processed.
+        """
+        from app.database import engine  # import here to keep module-level clean
+
+        if df.empty:
+            return 0
+
+        rows = []
+        for _, row in df.iterrows():
+            ticker = str(row["ticker"]).strip().upper()
+            fiscal_period = str(row["fiscal_period"]).strip()
+            metric = str(row["metric"]).strip()
+            category = str(row["category"]).strip()
+            period_end = row.get("period_end")
+            value = row["value"] if pd.notna(row.get("value")) else None
+            row_id = _make_row_id(ticker, fiscal_period, metric, category)
+            rows.append(
+                {
+                    "id": row_id,
+                    "ticker": ticker,
+                    "period_end": period_end,
+                    "fiscal_period": fiscal_period,
+                    "metric": metric,
+                    "category": category,
+                    "value": value,
+                }
+            )
+
+        upsert_stmt = sa.text(
+            """
+            INSERT INTO fundamentals
+                (id, ticker, period_end, fiscal_period, metric, category, value)
+            VALUES
+                (:id, :ticker, :period_end, :fiscal_period, :metric, :category, :value)
+            ON CONFLICT (ticker, fiscal_period, metric, category)
+            DO UPDATE SET
+                value      = EXCLUDED.value,
+                period_end = EXCLUDED.period_end
+            """
+        )
+
+        with engine.begin() as conn:
+            conn.execute(upsert_stmt, rows)
+
+        return len(rows)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def update_ticker_data(
+        self, ticker: str, force_refresh: bool = False
+    ) -> Dict:
+        """
+        Fetch the latest quarterly data for *ticker* from Yahoo Finance and
+        upsert it into the `fundamentals` table.
+
+        `force_refresh=True` first deletes all existing rows for the ticker,
+        then inserts the freshly fetched data.
         """
         try:
-            # Load existing data
-            existing_df = self._get_existing_data()
-            
-            # Fetch new data
             new_data = await self.fetch_ticker_quarterly(ticker.upper())
-            
+
             if new_data.empty:
                 return {
-                    'success': False,
-                    'message': f'No data fetched for {ticker}',
-                    'ticker': ticker,
-                    'new_records': 0,
-                    'total_records': len(existing_df) if not existing_df.empty else 0
+                    "success": False,
+                    "message": f"No data fetched for {ticker}",
+                    "ticker": ticker,
+                    "new_records": 0,
                 }
-            
-            # Merge with existing data
-            if existing_df.empty:
-                updated_df = new_data
-            elif force_refresh:
-                # Remove old data for this ticker and add new
-                existing_df = existing_df[existing_df['Ticker'].str.upper() != ticker.upper()]
-                updated_df = pd.concat([existing_df, new_data], ignore_index=True)
-            else:
-                # Proper merge: remove stale rows for periods that have fresh data
-                # and for periods that are completely new, just append them.
-                new_periods_for_ticker = set(new_data['FiscalPeriod'].unique())
-                ticker_mask = (existing_df['Ticker'].str.upper() == ticker.upper())
-                period_mask = (existing_df['FiscalPeriod'].isin(new_periods_for_ticker))
-                
-                # Remove stale rows that will be replaced by new data
-                existing_df = existing_df[~(ticker_mask & period_mask)]
-                
-                # Add the fresh data
-                updated_df = pd.concat([existing_df, new_data], ignore_index=True)
-            
-            # Save updated data
-            if not self.fundamentals_path:
-                # Try to find or create file in appropriate location
-                # Priority: Railway volume > current directory > project root
-                possible_paths = [
-                    Path("/data/fundamentals_tall.parquet"),  # Railway volume
-                    Path("fundamentals_tall.parquet"),  # Current directory
-                    Path(__file__).parent.parent.parent.parent / "fundamentals_tall.parquet",
-                ]
-                
-                for path in possible_paths:
-                    # Use first path that exists (for parent directory) or current directory
-                    if path.parent.exists() or path == Path("fundamentals_tall.parquet"):
-                        self.fundamentals_path = path
-                        break
-                
-                # Fallback to current directory if nothing found
-                if not self.fundamentals_path:
-                    self.fundamentals_path = Path("fundamentals_tall.parquet")
-            
-            # Ensure parent directory exists
-            self.fundamentals_path.parent.mkdir(parents=True, exist_ok=True)
-            
-            # Save the updated data
-            updated_df.to_parquet(self.fundamentals_path, index=False)
-            logger.info(f"Saved {len(updated_df):,} records to {self.fundamentals_path}")
-            
-            new_count = len(new_data)
-            total_count = len(updated_df)
-            existing_count = len(existing_df) if not existing_df.empty else 0
-            
-            logger.info(f"Updated {ticker}: {new_count} new records, {total_count} total records")
-            
+
+            if force_refresh:
+                from app.database import engine
+                with engine.begin() as conn:
+                    conn.execute(
+                        sa.text(
+                            "DELETE FROM fundamentals WHERE ticker = :ticker"
+                        ),
+                        {"ticker": ticker.upper()},
+                    )
+                logger.info(f"Deleted existing rows for {ticker} (force_refresh)")
+
+            count = self._upsert_to_db(new_data)
+            logger.info(f"Upserted {count} rows for {ticker} into DB")
+
             return {
-                'success': True,
-                'message': f'Successfully updated data for {ticker}',
-                'ticker': ticker,
-                'new_records': new_count,
-                'existing_records': existing_count,
-                'total_records': total_count,
-                'file_path': str(self.fundamentals_path)
+                "success": True,
+                "message": f"Successfully updated data for {ticker}",
+                "ticker": ticker,
+                "new_records": count,
             }
-            
-        except Exception as e:
-            logger.error(f"Error updating data for {ticker}: {e}")
+
+        except Exception as exc:
+            logger.error(f"Error updating data for {ticker}: {exc}")
             return {
-                'success': False,
-                'message': f'Error updating {ticker}: {str(e)}',
-                'ticker': ticker,
-                'error': str(e)
+                "success": False,
+                "message": f"Error updating {ticker}: {exc}",
+                "ticker": ticker,
+                "error": str(exc),
             }
-    
-    async def update_all_tickers(self, tickers: Optional[List[str]] = None, 
-                                 batch_size: int = 10, 
-                                 delay: float = 0.5) -> Dict:
+
+    async def update_all_tickers(
+        self,
+        tickers: Optional[List[str]] = None,
+        batch_size: int = 10,
+        delay: float = 0.5,
+    ) -> Dict:
         """
-        Update fundamentals data for multiple tickers
-        
-        Args:
-            tickers: List of tickers to update. If None, uses available tickers.
-            batch_size: Number of tickers to process before saving
-            delay: Delay between requests (seconds)
-        
-        Returns:
-            Dict with update statistics
+        Update fundamentals for multiple tickers.
+        If *tickers* is None, reads the distinct ticker list from the DB.
         """
         if tickers is None:
-            # Get available tickers from existing data
-            existing_df = self._get_existing_data()
-            if not existing_df.empty and 'Ticker' in existing_df.columns:
-                tickers = sorted(existing_df['Ticker'].unique().tolist())
-            else:
-                # Fallback to common tickers
-                tickers = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'META', 'TSLA']
-        
+            try:
+                from app.database import engine
+                with engine.connect() as conn:
+                    rows = conn.execute(
+                        sa.text(
+                            "SELECT DISTINCT ticker FROM fundamentals ORDER BY ticker"
+                        )
+                    ).fetchall()
+                tickers = [r[0] for r in rows] if rows else []
+            except Exception as exc:
+                logger.warning(f"Could not query tickers from DB: {exc}")
+                tickers = []
+
+            if not tickers:
+                # Sensible default when the table is still empty
+                tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA"]
+
         results = []
         total_updated = 0
         total_failed = 0
-        
+
         logger.info(f"Starting batch update for {len(tickers)} tickers")
-        
+
         for i, ticker in enumerate(tickers, 1):
-            logger.info(f"[{i}/{len(tickers)}] Updating {ticker}...")
-            
+            logger.info(f"[{i}/{len(tickers)}] Updating {ticker} …")
             result = await self.update_ticker_data(ticker, force_refresh=False)
             results.append(result)
-            
-            if result['success']:
+
+            if result["success"]:
                 total_updated += 1
             else:
                 total_failed += 1
-            
-            # Delay to avoid rate limiting
+
             if i < len(tickers):
                 time.sleep(delay)
-        
+
         return {
-            'success': True,
-            'total_tickers': len(tickers),
-            'updated': total_updated,
-            'failed': total_failed,
-            'results': results,
-            'file_path': str(self.fundamentals_path) if self.fundamentals_path else None
-        }
-    
-    async def get_latest_periods(self, ticker: Optional[str] = None) -> Dict:
-        """
-        Get information about the latest periods in the data
-        
-        Args:
-            ticker: Optional ticker to filter by
-        
-        Returns:
-            Dict with latest period info
-        """
-        existing_df = self._get_existing_data()
-        
-        if existing_df.empty:
-            return {
-                'latest_period': None,
-                'ticker_periods': {},
-                'total_records': 0
-            }
-        
-        if ticker:
-            existing_df = existing_df[existing_df['Ticker'].str.upper() == ticker.upper()]
-        
-        if existing_df.empty:
-            return {
-                'latest_period': None,
-                'ticker_periods': {},
-                'total_records': 0
-            }
-        
-        # Get latest period per ticker
-        ticker_periods = {}
-        for t in existing_df['Ticker'].unique():
-            ticker_data = existing_df[existing_df['Ticker'] == t]
-            periods = sorted(ticker_data['FiscalPeriod'].unique())
-            ticker_periods[t] = {
-                'latest': periods[-1] if periods else None,
-                'all_periods': periods,
-                'count': len(periods)
-            }
-        
-        # Overall latest period
-        all_periods = sorted(existing_df['FiscalPeriod'].unique())
-        latest_period = all_periods[-1] if all_periods else None
-        
-        return {
-            'latest_period': latest_period,
-            'ticker_periods': ticker_periods,
-            'total_records': len(existing_df),
-            'total_tickers': len(existing_df['Ticker'].unique())
+            "success": True,
+            "total_tickers": len(tickers),
+            "updated": total_updated,
+            "failed": total_failed,
+            "results": results,
         }
 
+    async def get_latest_periods(self, ticker: Optional[str] = None) -> Dict:
+        """
+        Return info about the latest fiscal periods stored in the DB.
+        """
+        try:
+            from app.database import engine
+
+            with engine.connect() as conn:
+                if ticker:
+                    rows = conn.execute(
+                        sa.text(
+                            """
+                            SELECT ticker, fiscal_period, COUNT(*) as cnt
+                            FROM fundamentals
+                            WHERE ticker = :ticker
+                            GROUP BY ticker, fiscal_period
+                            ORDER BY fiscal_period DESC
+                            """
+                        ),
+                        {"ticker": ticker.upper()},
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        sa.text(
+                            """
+                            SELECT ticker, fiscal_period, COUNT(*) as cnt
+                            FROM fundamentals
+                            GROUP BY ticker, fiscal_period
+                            ORDER BY ticker, fiscal_period DESC
+                            """
+                        )
+                    ).fetchall()
+
+            if not rows:
+                return {
+                    "latest_period": None,
+                    "ticker_periods": {},
+                    "total_records": 0,
+                }
+
+            ticker_periods: dict = {}
+            for t, fp, cnt in rows:
+                if t not in ticker_periods:
+                    ticker_periods[t] = {"latest": fp, "all_periods": [], "count": 0}
+                ticker_periods[t]["all_periods"].append(fp)
+                ticker_periods[t]["count"] += 1
+
+            all_periods = sorted({fp for _, fp, _ in rows})
+            latest = all_periods[-1] if all_periods else None
+
+            return {
+                "latest_period": latest,
+                "ticker_periods": ticker_periods,
+                "total_records": sum(cnt for _, _, cnt in rows),
+                "total_tickers": len(ticker_periods),
+            }
+
+        except Exception as exc:
+            logger.error(f"Error getting latest periods: {exc}")
+            return {"latest_period": None, "ticker_periods": {}, "total_records": 0}

--- a/finq-backend/app/services/data_source_manager.py
+++ b/finq-backend/app/services/data_source_manager.py
@@ -493,103 +493,53 @@ class DataSourceManager:
 
     async def get_fundamentals_data(self, ticker: str) -> pd.DataFrame:
         """
-        Get fundamentals data from parquet file
-        
-        Args:
-            ticker: Stock ticker symbol
-        
-        Returns:
-            DataFrame with fundamentals data
+        Get fundamentals data for a ticker from the PostgreSQL `fundamentals` table.
+
+        The data is stored in long/tall format:
+          ticker | period_end | fiscal_period | metric | category | value
+
+        Falls back to an empty DataFrame when the table has no data for the ticker.
         """
         cache_key = f"fundamentals_{ticker}"
-        
+
         if self._is_cache_valid(cache_key):
-            return self.cache[cache_key]
-        
+            cached = self.cache[cache_key]
+            logger.debug(f"Cache hit for fundamentals_{ticker}")
+            return cached
+
         try:
-            # Try multiple possible paths
-            # Railway runs from finq-backend/, so check current directory first
-            possible_paths = [
-                Path("fundamentals_tall.parquet"),  # Current directory (finq-backend/)
-                Path(settings.fundamentals_path),
-                Path(__file__).parent.parent.parent.parent / settings.fundamentals_path,
-                Path(__file__).parent.parent.parent.parent / "fundamentals_tall.parquet",
-                Path("../fundamentals_tall.parquet"),
-            ]
-            
-            fundamentals_path = None
-            for path in possible_paths:
-                if path.exists():
-                    fundamentals_path = path
-                    break
-            
-            if not fundamentals_path:
-                logger.warning(f"Fundamentals file not found. Tried: {possible_paths}")
+            from app.database import SessionLocal
+            import sqlalchemy as sa
+
+            ticker_upper = ticker.strip().upper()
+            logger.info(f"Fetching fundamentals from DB for {ticker_upper}")
+
+            with SessionLocal() as session:
+                rows = session.execute(
+                    sa.text(
+                        """
+                        SELECT ticker, period_end, fiscal_period, metric, category, value
+                        FROM   fundamentals
+                        WHERE  ticker = :ticker
+                        ORDER  BY fiscal_period DESC
+                        """
+                    ),
+                    {"ticker": ticker_upper},
+                ).fetchall()
+
+            if not rows:
+                logger.warning(f"No fundamentals rows found in DB for {ticker_upper}")
                 return pd.DataFrame()
-            
-            logger.info(f"Loading fundamentals from {fundamentals_path}")
-            df = pd.read_parquet(fundamentals_path)
-            
-            # Try different column name variations
-            ticker_col = None
-            for col in ['ticker', 'Ticker', 'TICKER']:
-                if col in df.columns:
-                    ticker_col = col
-                    break
-            
-            if ticker_col:
-                ticker_data = df[df[ticker_col].str.upper() == ticker.upper()].copy()
-                logger.info(f"Found {len(ticker_data)} rows for ticker {ticker}")
-                
-                # Sort by FiscalPeriod to ensure latest data is first
-                # Try different column name variations for period
-                period_col = None
-                for col in ['FiscalPeriod', 'fiscalPeriod', 'Period', 'period', 'Date', 'date']:
-                    if col in ticker_data.columns:
-                        period_col = col
-                        break
-                
-                if period_col:
-                    # Sort by period (descending - latest first)
-                    # Handle period formats like "2025 Q3", "2024 Q4", etc.
-                    def parse_period(period_str):
-                        """Parse period string to sortable tuple (year, quarter)"""
-                        try:
-                            if pd.isna(period_str):
-                                return (0, 0)
-                            period_str = str(period_str).strip()
-                            # Handle formats like "2025 Q3", "2025Q3", "2025-03", etc.
-                            if 'Q' in period_str.upper():
-                                parts = period_str.upper().split('Q')
-                                year = int(parts[0].strip())
-                                quarter = int(parts[1].strip()) if len(parts) > 1 else 0
-                                return (year, quarter)
-                            elif '-' in period_str:
-                                # Handle "2025-03" format
-                                parts = period_str.split('-')
-                                year = int(parts[0])
-                                quarter = int(parts[1]) // 3 if len(parts) > 1 else 0
-                                return (year, quarter)
-                            else:
-                                # Try to parse as year
-                                year = int(period_str[:4]) if len(period_str) >= 4 else 0
-                                return (year, 0)
-                        except:
-                            return (0, 0)
-                    
-                    # Add a temporary sort column
-                    ticker_data['_sort_period'] = ticker_data[period_col].apply(parse_period)
-                    ticker_data = ticker_data.sort_values('_sort_period', ascending=False)
-                    ticker_data = ticker_data.drop('_sort_period', axis=1)
-                    logger.info(f"Sorted fundamentals data by {period_col} (latest first)")
-            else:
-                logger.warning("No ticker column found in fundamentals data")
-                ticker_data = pd.DataFrame()
-            
+
+            ticker_data = pd.DataFrame(
+                rows,
+                columns=["Ticker", "PeriodEnd", "FiscalPeriod", "Metric", "Category", "Value"],
+            )
+            logger.info(f"Loaded {len(ticker_data)} fundamentals rows for {ticker_upper} from DB")
+
             self._cache_data(cache_key, ticker_data, ttl=settings.cache_ttl_financials)
-            
             return ticker_data
-            
+
         except Exception as e:
             logger.error(f"Error fetching fundamentals data for {ticker}: {e}")
             import traceback
@@ -598,62 +548,35 @@ class DataSourceManager:
     
     def get_available_tickers(self) -> List[str]:
         """
-        Get list of available tickers from fundamentals data or data directory
-        
-        Returns:
-            List of ticker symbols
+        Return the list of distinct tickers present in the `fundamentals` DB table.
+        Falls back to a hardcoded S&P-500 subset when the table is empty/unavailable.
         """
+        _FALLBACK = [
+            'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'META', 'TSLA', 'BRK.B', 'V', 'JNJ',
+            'WMT', 'JPM', 'MA', 'PG', 'UNH', 'HD', 'DIS', 'BAC', 'ADBE', 'NFLX',
+            'PYPL', 'CMCSA', 'XOM', 'VZ', 'CSCO', 'AVGO', 'COST', 'PFE', 'MRK', 'TMO',
+            'ABT', 'ACN', 'NKE', 'LIN', 'DHR', 'PM', 'TXN', 'NEE', 'HON', 'QCOM',
+        ]
         try:
-            # Try fundamentals file first (check multiple possible paths)
-            possible_paths = [
-                Path(settings.fundamentals_path),
-                Path(__file__).parent.parent.parent.parent / settings.fundamentals_path,
-                Path(__file__).parent.parent.parent.parent / "fundamentals_tall.parquet",
-                Path("../fundamentals_tall.parquet"),
-            ]
-            
-            for fundamentals_path in possible_paths:
-                if fundamentals_path.exists():
-                    try:
-                        df = pd.read_parquet(fundamentals_path)
-                        # Try different column name variations
-                        for col in ['ticker', 'Ticker', 'TICKER']:
-                            if col in df.columns:
-                                tickers = sorted(df[col].str.upper().unique().tolist())
-                                if tickers:
-                                    logger.info(f"Found {len(tickers)} tickers from {fundamentals_path}")
-                                    return tickers
-                    except Exception as e:
-                        logger.warning(f"Error reading {fundamentals_path}: {e}")
-                        continue
-            
-            # Fallback to data directory
-            data_dir_paths = [
-                Path(settings.data_dir),
-                Path(__file__).parent.parent.parent.parent / settings.data_dir,
-            ]
-            
-            for data_dir in data_dir_paths:
-                if data_dir.exists():
-                    tickers = [d.name for d in data_dir.iterdir() if d.is_dir() and not d.name.startswith('.')]
-                    if tickers:
-                        return sorted(tickers)
-            
-            # Final fallback: return common S&P 500 tickers
-            logger.warning("No tickers found in data files, using fallback list")
-            return [
-                'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'META', 'TSLA', 'BRK.B', 'V', 'JNJ',
-                'WMT', 'JPM', 'MA', 'PG', 'UNH', 'HD', 'DIS', 'BAC', 'ADBE', 'NFLX',
-                'PYPL', 'CMCSA', 'XOM', 'VZ', 'CSCO', 'AVGO', 'COST', 'PFE', 'MRK', 'TMO',
-                'ABT', 'ACN', 'NKE', 'LIN', 'DHR', 'PM', 'TXN', 'NEE', 'HON', 'QCOM'
-            ]
+            from app.database import SessionLocal
+            import sqlalchemy as sa
+
+            with SessionLocal() as session:
+                rows = session.execute(
+                    sa.text("SELECT DISTINCT ticker FROM fundamentals ORDER BY ticker")
+                ).fetchall()
+
+            tickers = [r[0] for r in rows]
+            if tickers:
+                logger.info(f"Found {len(tickers)} tickers in DB fundamentals table")
+                return tickers
+
+            logger.warning("fundamentals table is empty, using fallback ticker list")
+            return _FALLBACK
+
         except Exception as e:
-            logger.error(f"Error getting available tickers: {e}")
-            # Return fallback list on error
-            return [
-                'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'META', 'TSLA', 'BRK.B', 'V', 'JNJ',
-                'WMT', 'JPM', 'MA', 'PG', 'UNH', 'HD', 'DIS', 'BAC', 'ADBE', 'NFLX'
-            ]
+            logger.error(f"Error getting available tickers from DB: {e}")
+            return _FALLBACK
 
 
     def search_tickers(self, query: str, limit: int = 10) -> List[Dict[str, str]]:

--- a/finq-backend/scripts/seed_fundamentals.py
+++ b/finq-backend/scripts/seed_fundamentals.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Seeder: fundamentals_tall.parquet → PostgreSQL (Neon/Supabase)
+================================================================
+Reads the local parquet file and bulk-inserts all rows into the
+`fundamentals` table using psycopg2's efficient COPY protocol via
+execute_values for maximum throughput.
+
+Usage (from finq-backend/ directory):
+    source venv/bin/activate
+    python scripts/seed_fundamentals.py
+
+Optional env overrides:
+    PARQUET_PATH=path/to/fundamentals_tall.parquet   (default: auto-detect)
+    BATCH_SIZE=5000                                   (default: 5000)
+    TRUNCATE_FIRST=true                               (default: false)
+"""
+
+import os
+import sys
+import time
+import logging
+from pathlib import Path
+
+# ── Make sure we can import app modules ──────────────────────────────────────
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+import psycopg2
+from psycopg2.extras import execute_values
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+DATABASE_URL: str = os.environ["DATABASE_URL"]          # must be set
+BATCH_SIZE: int = int(os.getenv("BATCH_SIZE", "5000"))
+TRUNCATE_FIRST: bool = os.getenv("TRUNCATE_FIRST", "false").lower() == "true"
+
+# Parquet path: env override > auto-detect near this script
+_PARQUET_CANDIDATES = [
+    os.getenv("PARQUET_PATH", ""),
+    str(Path(__file__).parent.parent / "fundamentals_tall.parquet"),
+    str(Path(__file__).parent.parent.parent / "fundamentals_tall.parquet"),
+]
+PARQUET_PATH: Path | None = next(
+    (Path(p) for p in _PARQUET_CANDIDATES if p and Path(p).exists()), None
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_row_id(ticker: str, fiscal_period: str, metric: str, category: str) -> str:
+    """Deterministic surrogate PK matching the model definition."""
+    return f"{ticker}|{fiscal_period}|{metric}|{category}"
+
+
+def _build_dsn(url: str) -> str:
+    """
+    Strip query-string params that psycopg2 doesn't accept in DSN form
+    (e.g. channel_binding) but keep sslmode.
+    """
+    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    # Keep only params psycopg2 understands
+    allowed = {"sslmode", "sslcert", "sslkey", "sslrootcert", "application_name"}
+    filtered = {k: v for k, v in params.items() if k in allowed}
+    new_query = urlencode({k: v[0] for k, v in filtered.items()})
+    clean = parsed._replace(query=new_query)
+    return urlunparse(clean)
+
+
+def load_parquet(path: Path) -> pd.DataFrame:
+    logger.info(f"Loading parquet from {path} …")
+    df = pd.read_parquet(path)
+    # Normalise column names to lowercase
+    df.columns = [c.lower() for c in df.columns]
+    # Rename to match our DB columns
+    rename_map = {
+        "ticker": "ticker",
+        "periodend": "period_end",
+        "fiscalperiod": "fiscal_period",
+        "metric": "metric",
+        "category": "category",
+        "value": "value",
+    }
+    df = df.rename(columns=rename_map)
+    required = {"ticker", "fiscal_period", "metric", "category", "value"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Parquet is missing columns: {missing}")
+    logger.info(f"Loaded {len(df):,} rows, {df['ticker'].nunique()} tickers")
+    return df
+
+
+def seed(df: pd.DataFrame, conn) -> None:
+    cur = conn.cursor()
+
+    if TRUNCATE_FIRST:
+        logger.warning("TRUNCATE_FIRST=true — deleting all existing rows …")
+        cur.execute("TRUNCATE TABLE fundamentals RESTART IDENTITY;")
+        conn.commit()
+
+    # Deduplicate rows because PostgreSQL ON CONFLICT DO UPDATE requires all
+    # inserted rows in a single statement to be strictly unique on the conflict target.
+    # We keep the 'last' occurrence, which assumes order in the file tends towards newer.
+    df = df.drop_duplicates(subset=["ticker", "fiscal_period", "metric", "category"], keep="last")
+    total = len(df)
+    logger.info(f"Deduplicated to {total:,} unique rows.")
+
+    inserted = 0
+    skipped = 0
+    t0 = time.time()
+
+    for batch_start in range(0, total, BATCH_SIZE):
+        batch = df.iloc[batch_start : batch_start + BATCH_SIZE]
+
+        rows = []
+        for _, row in batch.iterrows():
+            ticker = str(row["ticker"]).strip().upper()
+            fiscal_period = str(row["fiscal_period"]).strip()
+            metric = str(row["metric"]).strip()
+            category = str(row["category"]).strip()
+            period_end = row.get("period_end")
+            value = row["value"] if pd.notna(row["value"]) else None
+            row_id = _make_row_id(ticker, fiscal_period, metric, category)
+
+            # period_end: convert to date string or None
+            if pd.notna(period_end) and period_end:
+                try:
+                    period_end_str = pd.Timestamp(period_end).date().isoformat()
+                except Exception:
+                    period_end_str = None
+            else:
+                period_end_str = None
+
+            rows.append((row_id, ticker, period_end_str, fiscal_period, metric, category, value))
+
+        # Upsert: on conflict (unique key) update value and period_end
+        execute_values(
+            cur,
+            """
+            INSERT INTO fundamentals
+                (id, ticker, period_end, fiscal_period, metric, category, value)
+            VALUES %s
+            ON CONFLICT (ticker, fiscal_period, metric, category)
+            DO UPDATE SET
+                value      = EXCLUDED.value,
+                period_end = EXCLUDED.period_end
+            """,
+            rows,
+            template="(%s,%s,%s::date,%s,%s,%s,%s)",
+            page_size=BATCH_SIZE,
+        )
+        conn.commit()
+
+        inserted += len(rows)
+        elapsed = time.time() - t0
+        pct = inserted / total * 100
+        rps = inserted / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"  {inserted:,}/{total:,} rows ({pct:.1f}%) — {rps:,.0f} rows/s"
+        )
+
+    logger.info(
+        f"Seed complete: {inserted:,} rows inserted/updated, "
+        f"{skipped} skipped in {time.time()-t0:.1f}s"
+    )
+    cur.close()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if PARQUET_PATH is None:
+        logger.error(
+            "Could not find fundamentals_tall.parquet. "
+            "Set PARQUET_PATH env var or place the file in finq-backend/."
+        )
+        sys.exit(1)
+
+    logger.info(f"Database URL: {DATABASE_URL[:DATABASE_URL.find('@')+1]}***")
+    logger.info(f"Batch size  : {BATCH_SIZE:,}")
+    logger.info(f"Truncate    : {TRUNCATE_FIRST}")
+
+    df = load_parquet(PARQUET_PATH)
+
+    dsn = _build_dsn(DATABASE_URL)
+    logger.info("Connecting to database …")
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+
+    try:
+        seed(df, conn)
+    except Exception:
+        conn.rollback()
+        logger.exception("Seed failed — transaction rolled back.")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Migrates the financial fundamentals data storage from a local parquet file to a persistent Neon PostgreSQL database.

## Changes:
- **Created a new SQLAlchemy model**: `Fundamental` mapped to the `fundamentals` table.
- **Alembic Migration**: Added a migration script (`c3d4e5f6a7b8_add_fundamentals_table`) to create the DB table safely.
- **Data Pipeline**: Refactored `app/services/data_pipeline.py` to upset directly to PostgreSQL instead of saving a parquet file.
- **Data Source Manager**: Refactored `app/services/data_source_manager.py` to read fundamentals exclusively from the PostgreSQL DB.
- **Seeder Script**: Created `scripts/seed_fundamentals.py` to bulk insert the existing `fundamentals_tall.parquet` data into the new DB.